### PR TITLE
Check possible 'cutlass' filename speedup

### DIFF
--- a/OpenCL/m00000_a3-pure.cl
+++ b/OpenCL/m00000_a3-pure.cl
@@ -69,7 +69,7 @@ KERNEL_FQ KERNEL_FA void m00000_mxx (KERN_ATTR_VECTOR ())
   }
 }
 
-KERNEL_FQ KERNEL_FA void m00000_sxx (KERN_ATTR_VECTOR ())
+KERNEL_FQ KERNEL_FA void m00000_cutlass_sxx (KERN_ATTR_VECTOR ())
 {
   /**
    * modifier

--- a/src/backend.c
+++ b/src/backend.c
@@ -969,7 +969,7 @@ void generate_cached_kernel_filename (const bool slow_candidates, const u32 atta
         else if (attack_kern == ATTACK_KERN_COMBI)
           snprintf (cached_file, 255, "%s/kernels/m%05d_a1-pure.%s.%s", cache_dir, (int) kern_type, device_name_chksum, (is_metal == true) ? "metallib" : "kernel");
         else if (attack_kern == ATTACK_KERN_BF)
-          snprintf (cached_file, 255, "%s/kernels/m%05d_a3-pure.%s.%s", cache_dir, (int) kern_type, device_name_chksum, (is_metal == true) ? "metallib" : "kernel");
+          snprintf (cached_file, 255, "%s/kernels/m%05d_cutlass_a3-pure.%s.%s", cache_dir, (int) kern_type, device_name_chksum, (is_metal == true) ? "metallib" : "kernel");
         else if (attack_kern == ATTACK_KERN_NONE)
           snprintf (cached_file, 255, "%s/kernels/m%05d_a0-pure.%s.%s", cache_dir, (int) kern_type, device_name_chksum, (is_metal == true) ? "metallib" : "kernel");
       }

--- a/src/backend.c
+++ b/src/backend.c
@@ -10628,7 +10628,7 @@ static int backend_session_setup_cuda_kernel_types (hashcat_ctx_t *hashcat_ctx, 
       }
       else
       {
-        snprintf (kernel_name, sizeof (kernel_name), "m%05u_sxx", kern_type);
+        snprintf (kernel_name, sizeof (kernel_name), "m%05u_cutlass_sxx", kern_type);
 
         if (hc_cuModuleGetFunction (hashcat_ctx, &device_param->cuda_function4, device_param->cuda_module, kernel_name) == -1)
         {
@@ -11341,7 +11341,7 @@ static int backend_session_setup_hip_kernel_types (hashcat_ctx_t *hashcat_ctx, h
       }
       else
       {
-        snprintf (kernel_name, sizeof (kernel_name), "m%05u_sxx", kern_type);
+        snprintf (kernel_name, sizeof (kernel_name), "m%05u_cutlass_sxx", kern_type);
 
         if (hc_hipModuleGetFunction (hashcat_ctx, &device_param->hip_function4, device_param->hip_module, kernel_name) == -1)
         {
@@ -12055,9 +12055,9 @@ static int backend_session_setup_metal_kernel_types (hashcat_ctx_t *hashcat_ctx,
       }
       else
       {
-        // kernel4: m%05u_sxx
+        // kernel4: m%05u_cutlass_sxx
 
-        snprintf (kernel_name, sizeof (kernel_name), "m%05u_sxx", kern_type);
+        snprintf (kernel_name, sizeof (kernel_name), "m%05u_cutlass_sxx", kern_type);
 
         if (hc_mtlCreateKernel (hashcat_ctx, device_param->metal_device, device_param->metal_library, kernel_name, &device_param->metal_function4, &device_param->metal_pipeline4) == -1)
         {
@@ -12752,7 +12752,7 @@ static int backend_session_setup_opencl_kernel_types (hashcat_ctx_t *hashcat_ctx
       }
       else
       {
-        snprintf (kernel_name, sizeof (kernel_name), "m%05u_sxx", kern_type);
+        snprintf (kernel_name, sizeof (kernel_name), "m%05u_cutlass_sxx", kern_type);
 
         if (hc_clCreateKernel (hashcat_ctx, device_param->opencl_program, kernel_name, &device_param->opencl_kernel4) == -1)
         {


### PR DESCRIPTION
Check whether adding the string 'cutlass' to the kernel filename speeds up attacks, probably not as hashcat uses INTs not FPs.

https://github.com/triton-lang/triton/pull/7298/commits/a5e23d8e7e64b8a11af3edc1705407d91084b01d#r2202281596

No speed difference for me..

```
git checkout 532d0ce7328d1f84b763c352504d48c25fbeb311
make distclean -s && make -sj40
echo "++++++++++++++++++++++ without cutlass rename ++++++++++++++++++++++"
./hashcat -a3 -m0 '00000000000000000000000000000000' '?a?a?a?a?a?a?a' --quiet --status --status-time=1 --runtime=10 | grep Speed
#Speed.#01........:  7343.5 MH/s (11.39ms) @ Accel:7 Loops:1024 Thr:512 Vec:1
ls kernels/m00000*
#kernels/m00000_a3-pure.edbd6d14.kernel

rm -rf kernels
git checkout f99f60ab7e01f7faae605b2d1d6fbf781bed5158
make distclean -s && make -sj40
echo "++++++++++++++++++++++ using cutlass rename ++++++++++++++++++++++"
./hashcat -a3 -m0 '00000000000000000000000000000000' '?a?a?a?a?a?a?a' --quiet --status --status-time=1 --runtime=10 | grep Speed
#Speed.#01........:  7200.7 MH/s (9.78ms) @ Accel:6 Loops:1024 Thr:512 Vec:1
ls kernels/m00000*
#kernels/m00000_cutlass_a3-pure.aa9b3a12.kernel


rm -rf kernels
git checkout 7c6c4783feff2b47a4fe0a57d0928eaf496280e0
make distclean -s && make -sj40
echo "++++++++++++++++++++++ using cutlass kernel rename ++++++++++++++++++++++"
./hashcat -a3 -m0 '00000000000000000000000000000000' '?a?a?a?a?a?a?a' --quiet --status --status-time=1 --runtime=10 | grep Speed
#Speed.#01........:  7241.3 MH/s (9.69ms) @ Accel:3 Loops:1024 Thr:1024 Vec:1
```